### PR TITLE
Slightly reduce vertical padding in table cells

### DIFF
--- a/site/assets/styles/base.scss
+++ b/site/assets/styles/base.scss
@@ -127,7 +127,7 @@ code {
 
 table td,
 table th {
-  padding: 0.6rem 1.6rem;
+  padding: 0.4rem 1.6rem;
   border-color: #ddd;
   border-width: 1px;
 


### PR DESCRIPTION
## Summary

- Reduces the vertical padding of table cells from `0.6rem` to `0.4rem` (horizontal stays `1.6rem`) in `site/assets/styles/base.scss` — the `table td, table th` rule that actually governs rendered cell padding, since it loads after the theme stylesheet and outranks the theme's bare `th, td` rule on specificity.
- An earlier draft of this change added an override in `site/assets/scss/_content.scss`; review showed that rule could never win the cascade, so the governing rule is edited directly instead.

## Test plan

- `hugo --source site` builds clean.
- Verified the compiled `styles/base.min.*.css` ships `table td,table th{padding:.4rem 1.6rem;...}` with the border and dark-mode declarations intact, and that no later or more specific rule overrides it on pages with Markdown tables (e.g. `posts/reference`).