### PR TITLE
Reuse the blog list layout for Experiments

### DIFF
--- a/site/assets/styles/_experiments.scss
+++ b/site/assets/styles/_experiments.scss
@@ -1,0 +1,40 @@
+// The listing reuses the theme's shared `.list` markup — a right-aligned date
+// column beside the title — and only adds the blurb under each title.
+.experiments-list {
+  $description-color: #666;
+  $description-color-dark: #aaa;
+
+  // Entries are multi-line here, unlike the single-line blog list, so they need
+  // breathing room the shared rules don't provide.
+  $entry-spacing: 2.4rem;
+
+  .experiments li {
+    @include not-last {
+      margin-bottom: $entry-spacing;
+    }
+  }
+
+  // Takes the flex ratio the theme gives a bare `.title`, so the title and its
+  // blurb share one column and the blurb wraps under the title, not the date.
+  // `min-width: 0` keeps that ratio exact by letting the column shrink below its
+  // content's intrinsic width.
+  .experiment-body {
+    flex: 2;
+    min-width: 0;
+  }
+
+  .experiment-description {
+    margin: 0.4rem 0 0;
+    font-size: 1.5rem;
+    line-height: 1.4;
+    color: $description-color;
+
+    // Without this, `min-width: 0` lets a long unbreakable token spill out of
+    // the column and add horizontal scroll to the page.
+    overflow-wrap: anywhere;
+
+    @include dark-mode {
+      color: $description-color-dark;
+    }
+  }
+}

--- a/site/assets/styles/base.scss
+++ b/site/assets/styles/base.scss
@@ -1,5 +1,6 @@
 @import "./common.scss";
 @import "./author.scss";
+@import "./experiments.scss";
 @import "./home.scss";
 @import "./projects.scss";
 @import "./pagination.scss";

--- a/site/content/experiments/llm-explorer.md
+++ b/site/content/experiments/llm-explorer.md
@@ -3,7 +3,6 @@ title: "LLM Explorer"
 description: "An interactive scatter plot for comparing large language models on cost and speed."
 date: "2026-06-27"
 summary: "Plot popular language models by blended cost and output speed, then bend the assumptions — workload mix, request size, cache hit rate — to see how the trade-offs shift."
-weight: 1
 experiment: "llm-explorer"
 ---
 

--- a/site/content/experiments/quote-card.md
+++ b/site/content/experiments/quote-card.md
@@ -3,7 +3,6 @@ title: "Quote Card"
 description: "A client-side PNG quote generator: write a quote in Markdown, style the card, download the image."
 date: "2026-07-03"
 summary: "Turn a snippet of Markdown into a downloadable PNG quote card — font, borders, shadows, and colors tuned live on a canvas, rendered entirely in your browser."
-weight: 2
 experiment: "quote-card"
 ---
 

--- a/site/layouts/experiments/list.html
+++ b/site/layouts/experiments/list.html
@@ -10,12 +10,17 @@
     </header>
     {{ .Content }}
     <ul class="experiments">
-      {{ range sort .Pages "Params.weight" }}
-      <li class="experiment">
-        <a class="experiment-title" href="{{ .RelPermalink }}">{{ .Title }}</a>
-        {{ with .Params.summary | default .Params.description }}
-        <p class="experiment-description">{{ . }}</p>
-        {{ end }}
+      {{/* Newest first, like the blog list and the section's feed. */}}
+      {{ range .Pages.ByDate.Reverse }}
+      <li>
+        {{/* The span always renders so an undated entry keeps the date column. */}}
+        <span class="date">{{ with .Date }}{{ time.Format ($.Site.Params.dateFormat | default "January 2, 2006") . }}{{ end }}</span>
+        <div class="experiment-body">
+          <a class="title" href="{{ .RelPermalink }}">{{ .Title }}</a>
+          {{ with .Params.summary | default .Params.description }}
+          <p class="experiment-description">{{ . }}</p>
+          {{ end }}
+        </div>
       </li>
       {{ end }}
     </ul>


### PR DESCRIPTION
## Summary

The `/experiments/` listing rendered a bare title plus a blurb with no CSS of its own, so it inherited the shared `.list` rule that flexes each `<li>` on desktop — with no `.date`/`.title` children to flex, the title and the blurb ended up side by side.

Entries now use the same markup the blog list uses: a right-aligned date column beside a bold title, so the existing `.list` rules apply unchanged. The summary blurb is kept, sitting under the title in the title column in a muted tone.

Ordering moves from `weight` to newest-first by date, matching the blog list. The now-inert `weight:` keys are dropped so Hugo's default page order falls through to the same date order — otherwise `/experiments/index.xml` would serve the entries in exactly the reverse of the page.

An entry with no `date:` keeps its (empty) date column rather than printing `January 1, 0001`.

## Test plan

- `hugo --source site --destination out` builds clean (116 pages, no warnings).
- Verified `/experiments/index.html` and `/experiments/index.xml` now list in the same newest-first order; previously they were exact opposites.
- Diffed development and production builds of `main` vs this branch (fingerprint and SRI `integrity` normalized): only `experiments/index.html` and the `styles/base.css` bundle differ. `posts/index.html` is byte-identical — the blog list is untouched.
- Screenshotted `/experiments/` and `/posts/` at 1280px (same date/title columns) and at 800/768/390px for the mobile stack.
- Scratch content file with no `date:` renders an empty date column with alignment intact.
- Scratch markdown list in `_index.md` confirms the entry-spacing rule does not leak into `{{ .Content }}`.
- Blurb contrast measured at 5.50:1 on the painted background (WCAG AA for normal text).