### PR TITLE
Centre post-meta icons on their labels

### DIFF
--- a/site/assets/scss/_content.scss
+++ b/site/assets/scss/_content.scss
@@ -74,23 +74,48 @@
     }
 
     .post-meta {
+      // Rows are flex lines so each icon centres on its label rather than on the
+      // font's x-height midpoint. The gap also stands in for the inter-item white
+      // space that flex layout discards; the icon adds a margin on top of it,
+      // keeping the wider icon-to-label distance the inline layout had.
+      $meta-gap: 0.5rem;
+
+      > div,
+      .date > span {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: $meta-gap;
+      }
+
+      // Flex breaks lines on an item's max-content width, so a row holding one
+      // long label would push it whole to the next line and strand the icon.
+      // Rows that are just an icon and its label never break; the label's own
+      // text still wraps.
+      .role,
+      .client,
+      .date > span {
+        flex-wrap: nowrap;
+      }
+
       .icon {
         width: 1.6rem;
         height: 1.6rem;
         margin-left: 0;
-        margin-right: 0.5rem;
+        margin-right: $meta-gap;
+        flex-shrink: 0;
       }
 
       .date {
         .posted-on {
           margin-left: 0;
-          margin-right: 1.5rem;
+          // Sits beside the row gap, which together restore the original 1.5rem.
+          margin-right: 1rem;
         }
       }
 
       .tags {
         .tag {
-          display: inline-block;
           padding: 0.3rem 0.6rem;
           background-color: $alt-bg-color;
           border-radius: 0.6rem;

--- a/site/assets/styles/_experiments.scss
+++ b/site/assets/styles/_experiments.scss
@@ -1,0 +1,40 @@
+// The listing reuses the theme's shared `.list` markup — a right-aligned date
+// column beside the title — and only adds the blurb under each title.
+.experiments-list {
+  $description-color: #666;
+  $description-color-dark: #aaa;
+
+  // Entries are multi-line here, unlike the single-line blog list, so they need
+  // breathing room the shared rules don't provide.
+  $entry-spacing: 2.4rem;
+
+  .experiments li {
+    @include not-last {
+      margin-bottom: $entry-spacing;
+    }
+  }
+
+  // Takes the flex ratio the theme gives a bare `.title`, so the title and its
+  // blurb share one column and the blurb wraps under the title, not the date.
+  // `min-width: 0` keeps that ratio exact by letting the column shrink below its
+  // content's intrinsic width.
+  .experiment-body {
+    flex: 2;
+    min-width: 0;
+  }
+
+  .experiment-description {
+    margin: 0.4rem 0 0;
+    font-size: 1.5rem;
+    line-height: 1.4;
+    color: $description-color;
+
+    // Without this, `min-width: 0` lets a long unbreakable token spill out of
+    // the column and add horizontal scroll to the page.
+    overflow-wrap: anywhere;
+
+    @include dark-mode {
+      color: $description-color-dark;
+    }
+  }
+}

--- a/site/assets/styles/base.scss
+++ b/site/assets/styles/base.scss
@@ -1,5 +1,6 @@
 @import "./common.scss";
 @import "./author.scss";
+@import "./experiments.scss";
 @import "./home.scss";
 @import "./projects.scss";
 @import "./pagination.scss";

--- a/site/content/experiments/llm-explorer.md
+++ b/site/content/experiments/llm-explorer.md
@@ -3,7 +3,6 @@ title: "LLM Explorer"
 description: "An interactive scatter plot for comparing large language models on cost and speed."
 date: "2026-06-27"
 summary: "Plot popular language models by blended cost and output speed, then bend the assumptions — workload mix, request size, cache hit rate — to see how the trade-offs shift."
-weight: 1
 experiment: "llm-explorer"
 ---
 

--- a/site/content/experiments/quote-card.md
+++ b/site/content/experiments/quote-card.md
@@ -3,7 +3,6 @@ title: "Quote Card"
 description: "A client-side PNG quote generator: write a quote in Markdown, style the card, download the image."
 date: "2026-07-03"
 summary: "Turn a snippet of Markdown into a downloadable PNG quote card — font, borders, shadows, and colors tuned live on a canvas, rendered entirely in your browser."
-weight: 2
 experiment: "quote-card"
 ---
 

--- a/site/layouts/experiments/list.html
+++ b/site/layouts/experiments/list.html
@@ -10,12 +10,17 @@
     </header>
     {{ .Content }}
     <ul class="experiments">
-      {{ range sort .Pages "Params.weight" }}
-      <li class="experiment">
-        <a class="experiment-title" href="{{ .RelPermalink }}">{{ .Title }}</a>
-        {{ with .Params.summary | default .Params.description }}
-        <p class="experiment-description">{{ . }}</p>
-        {{ end }}
+      {{/* Newest first, like the blog list and the section's feed. */}}
+      {{ range .Pages.ByDate.Reverse }}
+      <li>
+        {{/* The span always renders so an undated entry keeps the date column. */}}
+        <span class="date">{{ with .Date }}{{ time.Format ($.Site.Params.dateFormat | default "January 2, 2006") . }}{{ end }}</span>
+        <div class="experiment-body">
+          <a class="title" href="{{ .RelPermalink }}">{{ .Title }}</a>
+          {{ with .Params.summary | default .Params.description }}
+          <p class="experiment-description">{{ . }}</p>
+          {{ end }}
+        </div>
       </li>
       {{ end }}
     </ul>


### PR DESCRIPTION
## Summary

On post, experiment and project pages the metadata icons (calendar, clock, person, folder, tag) sat slightly low against the adjacent text.

`.post-meta` was pure inline layout, so `vertical-align: middle` pinned each icon's centre to the parent font's **x-height** midpoint rather than the text's optical centre — a flat ~2.2px drop in every font tested.

Each metadata row is now a flex line with `align-items: center`, matching the idiom `_home.scss` and `_sidenotes.scss` already use. `gap` stands in for the inter-item whitespace flex discards, and the icon keeps its margin on top so the icon-to-label distance is preserved rather than halved.

Rows holding only an icon and its label (`.role`, `.client`, `.posted-on`, `.reading-time`) do not wrap: flex breaks lines on an item's max-content width, so a long single label would otherwise be pushed whole to the next line and strand its icon alone above it. `.posted-on`'s margin drops 1.5rem → 1rem so it plus the new row gap restores the original spacing exactly. A now-inert `display: inline-block` on tag chips is removed.

## Test plan

Measured in `chrome-headless-shell` with PT Sans confirmed loaded (cap height 16.1px at 23.04px; measurements deferred on `document.fonts.ready`).

- **Icon centre vs cap-height midpoint**, all rows on post/project/experiment pages: `main` **+2.23px** (too low) → this branch **−0.27px**. Tags row **+2.23 → +0.28**, where the icon centres exactly on the chip box (offset 0.000).
- **Orphaned icons**: swept 15 pages × 8 widths (320–1200). Zero occurrences on this branch; the intermediate wrap-everywhere approach produced 8, all on `.client` rows.
- **Spacing restored**: date→reading-time gap 19.188px on `main`, 19.188px here (an intermediate version drifted to 25.578px).
- **Removing `display: inline-block`** changes nothing: 0 mismatches in chip width, chip height and tags-row height across 5 pages × 8 widths.
- **No regressions**: full-page pixel diff at 1200px vs `main` — `/`, `/posts/`, `/projects/`, `/experiments/`, `/tags/`, `/404.html` all **0 differing pixels**. On entry pages every element below `.post-meta` has identical size and moved by a uniform −0.17px. Home-page `.icon-column` cards, `.social-links`, notice titles and the code-copy button are untouched.
- **320px**: no horizontal overflow on any project or experiment page.

Known trade-off: when a `.client` label wraps to two lines the icon centres between them rather than on the first line. Clearly preferable to the icon being stranded on its own line, which is what the alternative produced.